### PR TITLE
fix: Migration V1 and V2

### DIFF
--- a/src/main/java/dev/augusto/java10x/CadastroDeNinjas/Ninjas/Models/NinjaModel.java
+++ b/src/main/java/dev/augusto/java10x/CadastroDeNinjas/Ninjas/Models/NinjaModel.java
@@ -15,6 +15,7 @@ public class NinjaModel {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
     @Column (name = "nome")
     private String nome;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,9 @@
 spring.application.name=CadastroDeNinjas
 
 spring.datasource.driver-class-name=org.h2.Driver
-spring.datasource.url=${DATABASE_URL}
-spring.datasource.username=${DATABASE_USERNAME}
-spring.datasource.password=${DATABASE_PASSWORD}
+spring.datasource.url=jdbc:h2:mem:testdb
+spring.datasource.username=sa
+spring.datasource.password=
 
 # Configurações do JPA / Hibernate
 spring.jpa.hibernate.ddl-auto=update

--- a/src/main/resources/db/migrations/V1__Create_tb_missoes.sql
+++ b/src/main/resources/db/migrations/V1__Create_tb_missoes.sql
@@ -1,0 +1,7 @@
+-- V1: Criação da tabela tb_missoes
+
+CREATE TABLE tb_missoes (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    nome VARCHAR(255) NOT NULL,
+    dificuldade VARCHAR(50) NOT NULL
+);

--- a/src/main/resources/db/migrations/V2__Add_rank_tb_cadastro.sql
+++ b/src/main/resources/db/migrations/V2__Add_rank_tb_cadastro.sql
@@ -1,4 +1,0 @@
--- V2: Migrations para adicionar a coluna de RANK na tabela de cadastros
-
-ALTER TABLE tb_cadastro
-ADD COLUMN rank VARCHAR(255);

--- a/src/main/resources/db/migrations/V2__Create_tb_cadastro.sql
+++ b/src/main/resources/db/migrations/V2__Create_tb_cadastro.sql
@@ -1,0 +1,12 @@
+-- V2: Criação da tabela tb_cadastro e relacionamento com tb_missoes
+
+CREATE TABLE tb_cadastro (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    nome VARCHAR(255) NOT NULL,
+    email VARCHAR(255) UNIQUE NOT NULL,
+    img_url VARCHAR(255),
+    rank VARCHAR(50),
+    idade INT NOT NULL,
+    missoes_id BIGINT,
+    CONSTRAINT fk_missoes FOREIGN KEY (missoes_id) REFERENCES tb_missoes(id) ON DELETE SET NULL
+);


### PR DESCRIPTION
Alterado o model:
    private Long id; Nao existia o que fazia o JPA procurar em loop por algum ID do tipo Long que foi disponibilizado no repository.

Table V1 , V2
Criada 2 tabelas para organizar a migration, antes por nunca ter sido criado uma tabela previamente a V2 nao funcionava dando erro de validaçao o banco era apagado toda vez que inicializava impossibilitando a criacao de uma migration